### PR TITLE
ZERO DAY EXPLOIT FIX

### DIFF
--- a/src/Commands/Fun/Rate.cs
+++ b/src/Commands/Fun/Rate.cs
@@ -34,7 +34,7 @@ namespace Sushi.src.Commands.Fun
 
             var waifuRate = new Random().Next(0, 100);
 
-            await FollowupAsync($"{(user == null ? "You are" : user?.Username + "is")} a {waifuRate}/100 waifu");
+            await FollowupAsync($"{(user == null ? "You are" : user?.Username + " is")} a {waifuRate}/100 waifu");
         }
     }
 }


### PR DESCRIPTION
* Fixed ZERO day exploit that allows malicious thread actor to be mentioned without space character between his name and string 'is'